### PR TITLE
Feat/view event details

### DIFF
--- a/components/view-event-details.tsx
+++ b/components/view-event-details.tsx
@@ -48,23 +48,37 @@ export default function ViewEventDetails({ event }: ViewEventDetailsProps) {
 
               <div className="grid grid-cols-3 items-center gap-4">
                 <p className="font-medium">Start Date:</p>
-                <p className="col-span-2">{event.dateStart.toString()}</p>
+                <p className="col-span-2">{event.dateStart.toLocaleString()}</p>
               </div>
 
               <div className="grid grid-cols-3 items-center gap-4">
                 <p className="font-medium">End Date:</p>
-                <p className="col-span-2">{event.dateEnd.toString()}</p>
+                <p className="col-span-2">{event.dateEnd.toLocaleString()}</p>
               </div>
 
               <div className="grid grid-cols-3 items-center gap-4">
                 <p className="font-medium">Registration:</p>
-                <div className="col-span-2 space-y-1">
-                  <p>Open: {event.isRegistrationOpen ? "Yes" : "No"}</p>
-                  <p>Required: {event.isRegistrationRequired ? "Yes" : "No"}</p>
-                  <p>
-                    Open to Outsiders: {event.isOpenToOutsiders ? "Yes" : "No"}
-                  </p>
-                </div>
+                <p className="col-span-2">
+                  {event.isRegistrationOpen ? (
+                    <span className="text-green-600">Open</span>
+                  ) : (
+                    <span className="text-red-600">Closed</span>
+                  )}
+                </p>
+              </div>
+
+              <div className="grid grid-cols-3 items-center gap-4">
+                <p className="font-medium">Required:</p>
+                <p className="col-span-2">
+                  {event.isRegistrationRequired ? "Yes" : "No"}
+                </p>
+              </div>
+
+              <div className="grid grid-cols-3 items-center gap-4">
+                <p className="font-medium">Open to Outsiders:</p>
+                <p className="col-span-2">
+                  {event.isOpenToOutsiders ? "Yes" : "No"}
+                </p>
               </div>
 
               <div className="grid grid-cols-3 items-center gap-4">


### PR DESCRIPTION
- Added ViewOrganizationDetails component to display organization details in a dialog when clicked.

User Story: [#16 Admin Side: My Event Page](https://tree.taiga.io/project/miggyalino-adto-by-sysdev/us/16)

Pass an organization object to the ViewEventDetails component like this:

```
  const sampleEvent: Event = {
    id: "1",
    name: "Annual Tech Conference 2024",
    description: "Join us for a day of technology talks and workshops",
    dateStart: new Date("2024-03-15T09:00:00"),
    dateEnd: new Date("2024-03-15T17:00:00"),
    isRegistrationOpen: true,
    isRegistrationRequired: true,
    isOpenToOutsiders: false,
    orgId: "1",
    org: {
      id: "1",
      name: "Tech Club",
      email: "tech@example.com",
      password: "password123",
      isActive: true,
      isAdmin: false,
      events: [],
      organizationParents: [],
    },
    registrations: [],
    ticketCategories: [],
    formQuestions: [],
  };

  <ViewEventDetails event={sampleEvent} />;
```
