### PR TITLE
Feat/18 organization crud

### DIFF
--- a/app/(main)/organizations/[id]/edit/page.tsx
+++ b/app/(main)/organizations/[id]/edit/page.tsx
@@ -168,7 +168,8 @@ export default function EditOrganizationPage() {
           <AlertDialogHeader>
             <AlertDialogTitle>Save Changes</AlertDialogTitle>
             <AlertDialogDescription>
-              Are you sure you want to save the changes to this organization?
+              Are you sure you want to edit this organization? Information will
+              be saved.
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
@@ -188,8 +189,8 @@ export default function EditOrganizationPage() {
           <AlertDialogHeader>
             <AlertDialogTitle>Cancel Edit</AlertDialogTitle>
             <AlertDialogDescription>
-              Are you sure you want to cancel editing this organization? Your
-              changes will not be saved.
+              Are you sure you want to cancel editing this organization&apos;s
+              information? New information will not be saved.
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>

--- a/app/(main)/organizations/[id]/edit/page.tsx
+++ b/app/(main)/organizations/[id]/edit/page.tsx
@@ -166,7 +166,7 @@ export default function EditOrganizationPage() {
       <AlertDialog open={showSubmitDialog} onOpenChange={setShowSubmitDialog}>
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>Save Changes</AlertDialogTitle>
+            <AlertDialogTitle>Edit Organization</AlertDialogTitle>
             <AlertDialogDescription>
               Are you sure you want to edit this organization? Information will
               be saved.
@@ -187,7 +187,7 @@ export default function EditOrganizationPage() {
       <AlertDialog open={showCancelDialog} onOpenChange={setShowCancelDialog}>
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>Cancel Edit</AlertDialogTitle>
+            <AlertDialogTitle>Cancel Edit Organization</AlertDialogTitle>
             <AlertDialogDescription>
               Are you sure you want to cancel editing this organization&apos;s
               information? New information will not be saved.

--- a/app/(main)/organizations/[id]/edit/page.tsx
+++ b/app/(main)/organizations/[id]/edit/page.tsx
@@ -1,0 +1,205 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useRouter, useParams } from "next/navigation";
+import OrganizationsForm from "@/components/features/organizations/organizations-form";
+import { OrganizationSchema } from "@/lib/zod/organization.schema";
+import { toast } from "sonner";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+
+// Mock function to get organization by ID - replace with actual API call
+function getOrganizationById(id: string): OrganizationSchema | null {
+  const mockOrganizations = [
+    {
+      name: "Samahan Systems and Development",
+      acronym: "SYSDEV",
+      email: "samahan.sd@addu.edu.ph",
+      description: "A student organization focused on systems development",
+      facebook: "https://facebook.com/sysdev",
+      instagram: "https://instagram.com/sysdev",
+      x: "https://x.com/sysdev",
+      linkedin: "https://linkedin.com/company/sysdev",
+    },
+    {
+      name: "Organization X",
+      acronym: "ORGX",
+      email: "orgx@gmail.com",
+      description: "Another organization",
+      facebook: "",
+      instagram: "",
+      x: "",
+      linkedin: "",
+    },
+  ];
+
+  const index = parseInt(id) - 1;
+  return mockOrganizations[index] || null;
+}
+
+export default function EditOrganizationPage() {
+  const router = useRouter();
+  const params = useParams();
+  const [organization, setOrganization] = useState<OrganizationSchema | null>(
+    null
+  );
+  const [formData, setFormData] = useState<OrganizationSchema | null>(null);
+  const [showCancelDialog, setShowCancelDialog] = useState(false);
+  const [showSubmitDialog, setShowSubmitDialog] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    const id = params.id as string;
+
+    const storedOrg = sessionStorage.getItem("editOrganization");
+    if (storedOrg) {
+      try {
+        const organizationData = JSON.parse(storedOrg) as OrganizationSchema;
+        setOrganization(organizationData);
+        setIsLoading(false);
+        sessionStorage.removeItem("editOrganization");
+        return;
+      } catch (error) {
+        console.error("Error parsing stored organization data:", error);
+      }
+    }
+
+    const orgData = getOrganizationById(id);
+
+    if (!orgData) {
+      toast("Organization not found.", {
+        description: "The requested organization could not be found.",
+      });
+      router.push("/organizations");
+      return;
+    }
+
+    setOrganization(orgData);
+    setIsLoading(false);
+  }, [params.id, router]);
+
+  // Show dialog instead of updating immediately
+  const handleSubmit = (data: OrganizationSchema) => {
+    setFormData(data);
+    setShowSubmitDialog(true);
+  };
+
+  // Run update when confirmed
+  const confirmSubmit = async () => {
+    if (!formData) return;
+
+    try {
+      setIsSubmitting(true);
+
+      // TODO: Replace with actual API call
+      console.log("Updating organization:", formData);
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+
+      toast("Organization updated successfully.", {
+        description: "The organization details have been saved.",
+      });
+
+      router.push("/organizations");
+    } catch (error) {
+      console.error("Error updating organization:", error);
+      toast("Failed to update organization. Please try again.", {
+        description: "An error occurred while updating the organization.",
+      });
+    } finally {
+      setIsSubmitting(false);
+      setShowSubmitDialog(false);
+      setFormData(null);
+    }
+  };
+
+  const handleCancel = () => {
+    setShowCancelDialog(true);
+  };
+
+  const confirmCancel = () => {
+    setShowCancelDialog(false);
+    router.push("/organizations");
+  };
+
+  if (isLoading) {
+    return (
+      <div className="container w-full mt-14 ml-3">
+        <h1 className="font-bold text-3xl mb-6">Edit Organization</h1>
+        <div>Loading...</div>
+      </div>
+    );
+  }
+
+  if (!organization) {
+    return (
+      <div className="container w-full mt-14 ml-3">
+        <h1 className="font-bold text-3xl mb-6">Edit Organization</h1>
+        <div>Organization not found.</div>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <div className="container w-full mt-14 ml-3">
+        <h1 className="font-bold text-3xl mb-6">Edit Organization</h1>
+
+        <OrganizationsForm
+          onSubmit={handleSubmit}
+          onCancel={handleCancel}
+          defaultValues={organization}
+          isSubmitting={isSubmitting}
+          isEditMode={true}
+        />
+      </div>
+
+      {/* Submit confirmation dialog */}
+      <AlertDialog open={showSubmitDialog} onOpenChange={setShowSubmitDialog}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Save Changes</AlertDialogTitle>
+            <AlertDialogDescription>
+              Are you sure you want to save the changes to this organization?
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel onClick={() => setShowSubmitDialog(false)}>
+              No
+            </AlertDialogCancel>
+            <AlertDialogAction onClick={confirmSubmit} disabled={isSubmitting}>
+              {isSubmitting ? "Saving..." : "Yes"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      {/* Cancel confirmation dialog */}
+      <AlertDialog open={showCancelDialog} onOpenChange={setShowCancelDialog}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Cancel Edit</AlertDialogTitle>
+            <AlertDialogDescription>
+              Are you sure you want to cancel editing this organization? Your
+              changes will not be saved.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel onClick={() => setShowCancelDialog(false)}>
+              No
+            </AlertDialogCancel>
+            <AlertDialogAction onClick={confirmCancel}>Yes</AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}

--- a/app/(main)/organizations/create/page.tsx
+++ b/app/(main)/organizations/create/page.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import OrganizationsForm from "@/components/features/organizations/organizations-form";
+import { toast } from "sonner";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import type { OrganizationSchema as OrganizationType } from "@/lib/zod/organization.schema";
+// import { createOrganizationService } from "@/lib/api/services/createOrganizationService";
+
+export default function CreateOrganizationPage() {
+  const router = useRouter();
+  const [showCancelDialog, setShowCancelDialog] = useState(false);
+  const [showSubmitDialog, setShowSubmitDialog] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [formData, setFormData] = useState<OrganizationType | null>(null);
+
+  // When the form submits → open confirm dialog and store data
+  const handleSubmit = async (data: OrganizationType) => {
+    setFormData(data);
+    setShowSubmitDialog(true);
+  };
+
+  const confirmSubmit = async () => {
+    if (!formData) return;
+
+    try {
+      setIsSubmitting(true);
+
+      // Call the actual API service
+      // await createOrganizationService(formData);
+
+      toast("Organization created successfully.", {
+        description: "The organization has been added to the system.",
+      });
+
+      router.push("/organizations");
+    } catch (error) {
+      console.error("Error creating organization:", error);
+      toast("Failed to create organization. Please try again.", {
+        description: "An error occurred while creating the organization.",
+      });
+    } finally {
+      setIsSubmitting(false);
+      setShowSubmitDialog(false);
+      setFormData(null);
+    }
+  };
+
+  const handleCancel = () => {
+    setShowCancelDialog(true);
+  };
+
+  const confirmCancel = () => {
+    setShowCancelDialog(false);
+    router.push("/organizations");
+  };
+
+  return (
+    <>
+      <div className="font-figtree container w-full mt-14 ml-3">
+        <h1 className=" font-bold text-3xl mb-6 ">Create Organization</h1>
+
+        <OrganizationsForm
+          onSubmit={handleSubmit}
+          onCancel={handleCancel}
+          isSubmitting={isSubmitting}
+        />
+      </div>
+
+      {/* Submit confirmation dialog */}
+      <AlertDialog open={showSubmitDialog} onOpenChange={setShowSubmitDialog}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Create Organization</AlertDialogTitle>
+            <AlertDialogDescription>
+              Are you sure you want to create this organization?
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel onClick={() => setShowSubmitDialog(false)}>
+              No
+            </AlertDialogCancel>
+            <AlertDialogAction onClick={confirmSubmit} disabled={isSubmitting}>
+              {isSubmitting ? "Creating..." : "Yes"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      {/* Cancel confirmation dialog */}
+      <AlertDialog open={showCancelDialog} onOpenChange={setShowCancelDialog}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Cancel Create Organization</AlertDialogTitle>
+            <AlertDialogDescription>
+              Are you sure you want to cancel creating this organization?
+              Information will not be saved.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel onClick={() => setShowCancelDialog(false)}>
+              No
+            </AlertDialogCancel>
+            <AlertDialogAction onClick={confirmCancel}>Yes</AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}

--- a/app/(main)/organizations/page.tsx
+++ b/app/(main)/organizations/page.tsx
@@ -1,15 +1,19 @@
+"use client";
+
 import {
   Organizations,
-  columns,
+  getOrganizationColumns,
 } from "@/components/features/organizations/organizations-column";
-import { DataTable } from "@/components/ui/data-table"; // Import DataTable instead
+import { DataTable } from "@/components/ui/data-table";
 import { Button } from "@/components/ui/button";
 import { CirclePlusIcon } from "lucide-react";
+import { useRouter } from "next/navigation";
 
-async function getData(): Promise<Organizations[]> {
+function getData(): Organizations[] {
   //TODO: Replace with actual api data
   return [
     {
+      id: "1",
       name: "Samahan Systems and Development",
       acronym: "SYSDEV",
       email: "samahan.sd@addu.edu.ph",
@@ -17,6 +21,7 @@ async function getData(): Promise<Organizations[]> {
       icon: "#0000FF",
     },
     {
+      id: "2",
       name: "Organization X",
       acronym: "ORGX",
       email: "orgx@gmail.com",
@@ -24,6 +29,7 @@ async function getData(): Promise<Organizations[]> {
       icon: "#FF0000",
     },
     {
+      id: "3",
       name: "Organization Y",
       acronym: "hehe",
       email: "org-oops!@gmail.com",
@@ -33,17 +39,26 @@ async function getData(): Promise<Organizations[]> {
   ];
 }
 
-export default async function OrganizationsPage() {
-  const data = await getData();
+export default function OrganizationsPage() {
+  const router = useRouter();
+  const data = getData();
+  const columns = getOrganizationColumns(router);
+
+  const handleCreateOrganization = () => {
+    router.push("/organizations/create");
+  };
 
   return (
     <div className="container w-full mt-14 ml-3">
       <h1 className="font-medium text-5xl ml-6">Organizations</h1>
-      <div className="flex flex-row justify-end items-end mb-5">
-        <Button className="bg-secondary" variant={"default"}>
+      <div className="flex flex-row justify-end items-end mb-5 gap-2">
+        <Button
+          className="bg-secondary"
+          variant={"default"}
+          onClick={handleCreateOrganization}
+        >
           <CirclePlusIcon />
           Add Organization
-          {/* Add Onclick event for organization creation */}
         </Button>
       </div>
 

--- a/components/features/organizations/organizations-column.tsx
+++ b/components/features/organizations/organizations-column.tsx
@@ -137,18 +137,15 @@ export const getOrganizationColumns = (router: {
             </DropdownMenuItem>
             <ArchiveDialog
               triggerLabel={
-                <DropdownMenuItem className="justify-start font-normal">
+                <button className="w-full text-left px-2 py-1.5 text-sm hover:bg-accent">
                   Archive
-                </DropdownMenuItem>
+                </button>
               }
               title="Archive Organization"
-              description={`Are you sure you want to archive "${organization.name}"? This will remove it from the active organizations list.`}
+              description={`Are you sure you want to archive "${organization.name}"?`}
               confirmLabel="Archive"
-              variant="destructive"
-              //placeholder for now
-              onConfirm={() => {
-                handleArchive(organization);
-              }}
+              variant="default"
+              onConfirm={() => handleArchive(organization)}
             />
           </DropdownMenuContent>
         </DropdownMenu>

--- a/components/features/organizations/organizations-column.tsx
+++ b/components/features/organizations/organizations-column.tsx
@@ -11,19 +11,43 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
+import { toast } from "sonner";
+import { ArchiveDialog } from "@/components/shared/archive-dialog";
 
 export type Organizations = {
+  id?: string; // Add ID field for navigation
   name: string;
   acronym: string;
   email: string;
   orgEvents: number;
+  isActive?: boolean; // Add isActive field for archive functionality
   /**
    * TODO: REPLACE COLOR WITH ACTUAL ORG PICTURES
    * !PLACEHOLDER FOR NOW
    * **/
   icon?: string;
 };
-export const columns: ColumnDef<Organizations>[] = [
+
+// Helper functions for actions
+const handleEdit = (
+  organization: Organizations,
+  router: { push: (path: string) => void }
+) => {
+  // temporary way to pass organization data to the edit page
+  const id = organization.id || "1";
+  sessionStorage.setItem("editOrganization", JSON.stringify(organization));
+  router.push(`/organizations/${id}/edit`);
+};
+
+const handleArchive = (organization: Organizations) => {
+  toast(`"${organization.name}" has been archived successfully.`, {
+    description: "Organization archived successfully.",
+  });
+};
+
+export const getOrganizationColumns = (router: {
+  push: (path: string) => void;
+}): ColumnDef<Organizations>[] => [
   {
     id: "select",
     header: ({ table }) => {
@@ -93,7 +117,8 @@ export const columns: ColumnDef<Organizations>[] = [
 
   {
     id: "actions",
-    cell({}) {
+    cell({ row }) {
+      const organization = row.original;
       return (
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
@@ -107,8 +132,24 @@ export const columns: ColumnDef<Organizations>[] = [
           >
             <DropdownMenuLabel>Actions</DropdownMenuLabel>
             <DropdownMenuItem>View Details</DropdownMenuItem>
-            <DropdownMenuItem>Edit</DropdownMenuItem>
-            <DropdownMenuItem>Archive</DropdownMenuItem>
+            <DropdownMenuItem onClick={() => handleEdit(organization, router)}>
+              Edit
+            </DropdownMenuItem>
+            <ArchiveDialog
+              triggerLabel={
+                <DropdownMenuItem className="justify-start font-normal">
+                  Archive
+                </DropdownMenuItem>
+              }
+              title="Archive Organization"
+              description={`Are you sure you want to archive "${organization.name}"? This will remove it from the active organizations list.`}
+              confirmLabel="Archive"
+              variant="destructive"
+              //placeholder for now
+              onConfirm={() => {
+                handleArchive(organization);
+              }}
+            />
           </DropdownMenuContent>
         </DropdownMenu>
       );

--- a/components/features/organizations/organizations-form.tsx
+++ b/components/features/organizations/organizations-form.tsx
@@ -1,0 +1,214 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm } from "react-hook-form";
+
+import {
+  OrganizationSchema,
+  type OrganizationSchema as OrganizationType,
+} from "@/lib/zod/organization.schema";
+
+interface OrganizationsFormProps {
+  onSubmit: (data: OrganizationType) => void;
+  onCancel: () => void;
+  defaultValues?: Partial<OrganizationType>;
+  isSubmitting?: boolean;
+  isEditMode?: boolean;
+}
+
+export default function OrganizationsForm({
+  onSubmit,
+  onCancel,
+  defaultValues,
+  isSubmitting = false,
+  isEditMode = false,
+}: OrganizationsFormProps) {
+  const form = useForm<OrganizationType>({
+    resolver: zodResolver(OrganizationSchema),
+    defaultValues: {
+      name: "",
+      acronym: "",
+      email: "",
+      icon: null,
+      description: "",
+      facebook: "",
+      instagram: "",
+      x: "",
+      linkedin: "",
+      ...defaultValues,
+    },
+  });
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+        <FormField
+          control={form.control}
+          name="name"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Organization Name *</FormLabel>
+              <FormControl>
+                <Input placeholder="Enter organization name" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="acronym"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Organization Acronym</FormLabel>
+              <FormControl>
+                <Input placeholder="e.g., SYSDEV" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="email"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Email Address *</FormLabel>
+              <FormControl>
+                <Input type="email" placeholder="org@example.com" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        {/* <FormField
+          control={form.control}
+          name="password"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Temporary Password *</FormLabel>
+              <FormControl>
+                <Input
+                  type="password"
+                  placeholder="Minimum 6 characters"
+                  {...field}
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        /> */}
+
+        <FormField
+          control={form.control}
+          name="description"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Organization Description</FormLabel>
+              <FormControl>
+                <Textarea
+                  placeholder="Brief description of the organization"
+                  rows={4}
+                  {...field}
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <div className="grid grid-cols-1 gap-4">
+          {["facebook", "instagram", "x", "linkedin"].map((social) => (
+            <FormField
+              key={social}
+              control={form.control}
+              name={social as keyof OrganizationType}
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>
+                    {social.charAt(0).toUpperCase() + social.slice(1)} URL
+                  </FormLabel>
+                  <FormControl>
+                    <Input
+                      placeholder={`https://${social}.com/...`}
+                      {...field}
+                      value={String(field.value || "")}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          ))}
+        </div>
+
+        {/* <div className="flex space-x-6">
+          <FormField
+            control={form.control}
+            name="isActive"
+            render={({ field }) => (
+              <FormItem className="flex flex-row items-start space-x-3 space-y-0">
+                <FormControl>
+                  <Checkbox
+                    checked={field.value}
+                    onCheckedChange={field.onChange}
+                  />
+                </FormControl>
+                <div className="space-y-1 leading-none">
+                  <FormLabel>Active Organization</FormLabel>
+                </div>
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="isAdmin"
+            render={({ field }) => (
+              <FormItem className="flex flex-row items-start space-x-3 space-y-0">
+                <FormControl>
+                  <Checkbox
+                    checked={field.value}
+                    onCheckedChange={field.onChange}
+                  />
+                </FormControl>
+                <div className="space-y-1 leading-none">
+                  <FormLabel>Admin Organization</FormLabel>
+                </div>
+              </FormItem>
+            )}
+          />
+        </div> */}
+
+        <div className="flex justify-end space-x-4 pt-4">
+          <Button variant="outline" type="button" onClick={onCancel}>
+            Cancel
+          </Button>
+          <Button type="submit" variant="outline" disabled={isSubmitting}>
+            {isSubmitting
+              ? isEditMode
+                ? "Updating..."
+                : "Creating..."
+              : isEditMode
+                ? "Save Changes"
+                : "Create"}
+          </Button>
+        </div>
+      </form>
+    </Form>
+  );
+}

--- a/components/shared/archive-dialog.tsx
+++ b/components/shared/archive-dialog.tsx
@@ -3,23 +3,22 @@
 import * as React from "react";
 import {
   Dialog,
-  DialogTrigger,
   DialogContent,
-  DialogHeader,
-  DialogTitle,
   DialogDescription,
   DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 
-type ConfirmDialogProps = {
-  triggerLabel: React.ReactNode; // text or element for the trigger
-  title: string; // dialog title
-  description: string; // dialog description
-  confirmLabel?: string; // button text, e.g. "Archive"
-  cancelLabel?: string; // button text, e.g. "Cancel"
-  variant?: "default" | "destructive"; // style for confirm button
-  onConfirm: () => void; // what happens on confirm
+type ArchiveDialogProps = {
+  triggerLabel: React.ReactNode;
+  title: string;
+  description: string;
+  confirmLabel?: string;
+  variant?: "default" | "destructive";
+  onConfirm: () => void;
 };
 
 export function ArchiveDialog({
@@ -27,39 +26,27 @@ export function ArchiveDialog({
   title,
   description,
   confirmLabel = "Confirm",
-  cancelLabel = "Cancel",
-  variant = "default",
+  variant = "destructive",
   onConfirm,
-}: ConfirmDialogProps) {
+}: ArchiveDialogProps) {
   const [open, setOpen] = React.useState(false);
 
   const handleConfirm = () => {
     onConfirm();
-    setOpen(false);
+    setOpen(false); // ✅ close the dialog after action
   };
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
-      <DialogTrigger asChild>
-        <Button
-          variant="ghost"
-          className="w-full justify-start px-0 h-8"
-          onClick={(e) => {
-            e.preventDefault(); // prevent closing parent menu immediately
-            setOpen(true);
-          }}
-        >
-          {triggerLabel}
-        </Button>
-      </DialogTrigger>
-      <DialogContent className="sm:max-w-md">
+      <DialogTrigger asChild>{triggerLabel}</DialogTrigger>
+      <DialogContent>
         <DialogHeader>
           <DialogTitle>{title}</DialogTitle>
           <DialogDescription>{description}</DialogDescription>
         </DialogHeader>
-        <DialogFooter className="flex gap-2 justify-end">
+        <DialogFooter>
           <Button variant="outline" onClick={() => setOpen(false)}>
-            {cancelLabel}
+            Cancel
           </Button>
           <Button variant={variant} onClick={handleConfirm}>
             {confirmLabel}

--- a/components/shared/archive-dialog.tsx
+++ b/components/shared/archive-dialog.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import * as React from "react";
+import {
+  Dialog,
+  DialogTrigger,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+
+type ConfirmDialogProps = {
+  triggerLabel: React.ReactNode; // text or element for the trigger
+  title: string; // dialog title
+  description: string; // dialog description
+  confirmLabel?: string; // button text, e.g. "Archive"
+  cancelLabel?: string; // button text, e.g. "Cancel"
+  variant?: "default" | "destructive"; // style for confirm button
+  onConfirm: () => void; // what happens on confirm
+};
+
+export function ArchiveDialog({
+  triggerLabel,
+  title,
+  description,
+  confirmLabel = "Confirm",
+  cancelLabel = "Cancel",
+  variant = "default",
+  onConfirm,
+}: ConfirmDialogProps) {
+  const [open, setOpen] = React.useState(false);
+
+  const handleConfirm = () => {
+    onConfirm();
+    setOpen(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button
+          variant="ghost"
+          className="w-full justify-start px-0 h-8"
+          onClick={(e) => {
+            e.preventDefault(); // prevent closing parent menu immediately
+            setOpen(true);
+          }}
+        >
+          {triggerLabel}
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>{description}</DialogDescription>
+        </DialogHeader>
+        <DialogFooter className="flex gap-2 justify-end">
+          <Button variant="outline" onClick={() => setOpen(false)}>
+            {cancelLabel}
+          </Button>
+          <Button variant={variant} onClick={handleConfirm}>
+            {confirmLabel}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/lib/api/services/archiveOrganizationService.ts
+++ b/lib/api/services/archiveOrganizationService.ts
@@ -1,0 +1,14 @@
+import { BASE_URL } from "../../config/api";
+
+export const archiveOrganizationService = async (id: string) => {
+    const response = await fetch(`${BASE_URL}/organizations/${id}/archive`, {
+        method: "PATCH",
+    });
+
+    if (!response.ok) {
+        throw new Error("Event organization failed");
+    }
+
+    const data = await response.json();
+    return data;
+};

--- a/lib/api/services/createOrganizationService.ts
+++ b/lib/api/services/createOrganizationService.ts
@@ -1,0 +1,21 @@
+import { OrganizationRequest } from "@/lib/types/requests/Organization";
+import { BASE_URL } from "../../config/api";
+
+export const createOrganizationService = async (orgData: OrganizationRequest) => {
+
+    const response = await fetch(`${BASE_URL}/organizations`, {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json",
+        },
+        credentials: "include",
+        body: JSON.stringify(orgData),
+    });
+
+    if (!response.ok) {
+        throw new Error("Organization create failed");
+    }
+
+    const data = await response.json();
+    return data;
+};

--- a/lib/api/services/editOrganizationService.ts
+++ b/lib/api/services/editOrganizationService.ts
@@ -1,0 +1,21 @@
+import { OrganizationRequest } from "@/lib/types/requests/Organization";
+import { BASE_URL } from "../../config/api";
+
+export const editOrganizationService = async (id: string, orgData: OrganizationRequest) => {
+
+    const response = await fetch(`${BASE_URL}/organizations/${id}`, {
+        method: "PUT",
+        headers: {
+            "Content-Type": "application/json",
+        },
+        credentials: "include",
+        body: JSON.stringify(orgData),
+    });
+
+    if (!response.ok) {
+        throw new Error("Organization update failed");
+    }
+
+    const data = await response.json();
+    return data;
+};

--- a/lib/types/requests/Organization.ts
+++ b/lib/types/requests/Organization.ts
@@ -1,0 +1,14 @@
+export interface OrganizationRequest {
+    name: string;
+    acronym?: string;
+    email: string;
+    password: string;
+    icon?: File | null;
+    description?: string;
+    facebook?: string;
+    instagram?: string;
+    twitter?: string;
+    linkedin?: string;
+    isActive: boolean;
+    isAdmin: boolean;
+}

--- a/lib/zod/organization.schema.ts
+++ b/lib/zod/organization.schema.ts
@@ -1,0 +1,15 @@
+import { z } from "zod";
+
+export const OrganizationSchema = z.object({
+    name: z.string().min(1, "This is a required field"),
+    acronym: z.string().min(1, "This is a required field"),
+    email: z.string().min(1, "This is a required field").email("Invalid email"),
+    icon: z.instanceof(File).optional().or(z.literal(null)),
+    description: z.string().optional(),
+    facebook: z.string().url("Invalid URL").optional().or(z.literal("")),
+    instagram: z.string().url("Invalid URL").optional().or(z.literal("")),
+    x: z.string().url("Invalid URL").optional().or(z.literal("")),
+    linkedin: z.string().url("Invalid URL").optional().or(z.literal("")),
+});
+
+export type OrganizationSchema = z.infer<typeof OrganizationSchema>;


### PR DESCRIPTION
### Issue ticket number and link
<!-- Follow the format "Resolves TICKET_NUMBER - [TICKET_NAME](https://huly.app/workbench/adto/tracker/link-to-ticket)" -->
Resolves 18 - [Implement Organization CRUD Functionality ](https://huly.app/workbench/adto/tracker/ADTO-18)


# Features

- Added forms, schemas, and pages scaffolded for CRUD operations.
- Implemented initial dialog flows (create, edit, archive).
- Integrated with form validation using Zod + react-hook-form.
- Set up confirmation dialogs for create, edit, cancel, and archive actions


### Notes
- Most service calls (API integrations) are still placeholders.
- Forms, schemas, and pages exist but require testing with real services once implemented.
- Current functionality mainly demonstrates UI flow and validation; actual data persistence is not yet wired up.
- Most of the Confirmation Buttons and Toasts are not styled properly

### Usage
- Developers can already navigate to create/edit pages and test form validation + confirmation dialogs.
- On submit, placeholders (toast) are triggered until services are connected.

### TODO

- Hook up actual CRUD services (create, read, update, delete).
- Test forms and pages against backend endpoints.
- Refine validation/error handling once APIs are integrated.
- Toast and button designs are still not finished 

# Screenshots
<!-- Attach images of your proposed changes. -->

### Mobile view

<img width="420" height="893" alt="image" src="https://github.com/user-attachments/assets/71366182-e1cf-47b8-9045-42c20b6445f2" />

<img width="416" height="892" alt="image" src="https://github.com/user-attachments/assets/dd977fcc-449e-41e5-a83c-333d105a0fbe" />

*see desktop view for complete screenshots 

### Desktop view

<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/785beaf5-27a2-40b4-bf28-b60c9e242d74" />

<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/b9d4ffbd-5173-485b-985f-ae2b803e135c" />

<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/fce1510d-27b2-4557-bf17-ed273f2f85f6" />


<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/0f621ba1-0b17-4150-a804-376d6f04a295" />

<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/8780bd06-7e7d-414c-940b-a045ce95d76b" />

<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/35e2d1ef-e8c7-4057-9136-7e113fe61c2b" />

<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/3ff674a9-82c3-467f-aee6-a1836acc554b" />


