### PR TITLE
fix: rename env variable name for backend base url

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_BACKEND_BASE_URL=http://localhost:8080/api

--- a/lib/config/api.ts
+++ b/lib/config/api.ts
@@ -1,2 +1,2 @@
 export const BASE_URL =
-  process.env.BACKEND_BASE_URL || "http://localhost:8080/api";
+  process.env.NEXT_PUBLIC_BACKEND_BASE_URL || "http://localhost:8080/api";


### PR DESCRIPTION
Feat: rename the env variable from BACKEND_BASE_URL to NEXT_PUBLIC_BACKEND_BASE_URL
