### PR TITLE
fix: add description preview with truncation to events and disable hiding for registration columns

### DIFF
--- a/components/features/events/events-columns.tsx
+++ b/components/features/events/events-columns.tsx
@@ -21,6 +21,24 @@ interface EventsColumnsProps {
   onViewEvent?: (event: Event) => void;
 }
 
+const DESCRIPTION_PREVIEW_MAX_LENGTH = 100;
+
+const getDescriptionPreview = (description: string) => {
+  const normalizedDescription = description?.trim() || "";
+
+  if (normalizedDescription.length <= DESCRIPTION_PREVIEW_MAX_LENGTH) {
+    return {
+      text: normalizedDescription,
+      truncated: false,
+    };
+  }
+
+  return {
+    text: normalizedDescription.slice(0, DESCRIPTION_PREVIEW_MAX_LENGTH),
+    truncated: true,
+  };
+};
+
 export const createEventsColumns = ({
   onArchiveEvent,
   onViewEvent,
@@ -52,11 +70,21 @@ export const createEventsColumns = ({
     header: () => <span className="text-secondary-100">Event Name</span>,
     cell: ({ row }) => {
       const event = row.original;
+      const descriptionPreview = getDescriptionPreview(event.description);
+
       return (
         <div className="space-y-1">
           <div className="font-medium">{event.name}</div>
-          <div className="text-sm text-muted-foreground line-clamp-2">
-            {event.description}
+          <div className="text-sm text-muted-foreground line-clamp-2 break-words">
+            {descriptionPreview.text}
+            {descriptionPreview.truncated && (
+              <>
+                ...{" "}
+                <span className="cursor-pointer text-secondary-400">
+                  See more
+                </span>
+              </>
+            )}
           </div>
         </div>
       );

--- a/components/features/registrations/registration-columns.tsx
+++ b/components/features/registrations/registration-columns.tsx
@@ -41,6 +41,7 @@ export const createRegistrationsColumns = ({
       const registration = row.original;
       return <div className="font-medium">{registration.fullName}</div>;
     },
+    enableHiding: false,
   },
   {
     accessorKey: "email",
@@ -49,6 +50,7 @@ export const createRegistrationsColumns = ({
       const registration = row.original;
       return <div className="font-medium">{registration.email}</div>;
     },
+    enableHiding: false,
   },
   {
     accessorKey: "cluster",


### PR DESCRIPTION
### "Resolves 84 - [Admin Side:[QA] My Events - Registration Tab](https://huly.app/workbench/adto/tracker/ADTO-84)"
### "Resolves 85 - [Admin Side:[QA] My Events Page Description](https://huly.app/workbench/adto/tracker/ADTO-85)"

# Features

- Added See more for long event descriptions in the Events table.
- Removed Full Name and Email from the Registration table’s Customize Columns options so the table always retains essential visible data even when other columns are unchecked.

# Screenshots

Registration Table:

<img width="1890" height="978" alt="image" src="https://github.com/user-attachments/assets/bbebe903-e1d9-40ca-9633-3a204360a483" />

Events Page Description:
<img width="1893" height="991" alt="image" src="https://github.com/user-attachments/assets/5770fca9-b803-41fd-a73a-bf1f12fdd234" />